### PR TITLE
Fix elemental ignore with new valk gears

### DIFF
--- a/js/head.js
+++ b/js/head.js
@@ -3539,9 +3539,23 @@ function BattleMagicCalc(wBMC) {
 	if (SkillSearch(445) && (6 == target_element || 7 == target_element) && n_A_Weapon_zokusei > 0 && n_A_Weapon_zokusei < 5)
 		elemental_resistance = Math.min(elemental_resistance + 0.5, 1);
 
-	// [Prima's Vanity#1889] adds ignore 20% of Holy/Shadow element Fire/Water/Wind/Earth Resistance, limited to 100%.		
-	if (EquipNumSearch(1889) && (6 == target_element || 7 == target_element) && n_A_Weapon_zokusei > 0 && n_A_Weapon_zokusei < 5)
-		elemental_resistance = Math.min(elemental_resistance + 0.2, 1);
+	// Valkyrie gear resist ignore are not effective when the user has Wizard Spirit.
+	else{
+		if ((6 == target_element || 7 == target_element) && n_A_Weapon_zokusei > 0 && n_A_Weapon_zokusei < 5){
+			// Wearing both [Reginleif's Brand#1888] and [Prima's Vanity#1889] adds ignore 25% of Holy/Shadow element Fire/Water/Wind/Earth Resistance.
+			if (EquipNumSearch(1888) && EquipNumSearch(1889)){
+				elemental_resistance = Math.min(elemental_resistance + 0.25, 1);
+			}
+			// [Reginleif's Brand#1888] adds ignore 10% of Holy/Shadow element Fire/Water/Wind/Earth Resistance.
+			else if (EquipNumSearch(1888)){
+				elemental_resistance = Math.min(elemental_resistance + 0.1, 1);
+			}
+			// [Prima's Vanity#1889] adds ignore 20% of Holy/Shadow element Fire/Water/Wind/Earth Resistance.
+			else if (EquipNumSearch(1889)){
+				elemental_resistance = Math.min(elemental_resistance + 0.2, 1);
+			}
+		}
+	}
 	
 	wBMC2 = Math.floor(wBMC2 * elemental_resistance); // Apply elemental weakness
 	if (debug_dmg_avg)

--- a/js/head.js
+++ b/js/head.js
@@ -3535,23 +3535,28 @@ function BattleMagicCalc(wBMC) {
 	let elemental_resistance = zokusei[n_B[3]][n_A_Weapon_zokusei];
 	let target_element = Math.floor(n_B[3] / 10);
 	
-	// [Wizard Link#445] adds ignore 50% of Holy/Shadow element Fire/Water/Wind/Earth Resistance, limited to 100%.		
-	if (SkillSearch(445) && (6 == target_element || 7 == target_element) && n_A_Weapon_zokusei > 0 && n_A_Weapon_zokusei < 5)
-		elemental_resistance = Math.min(elemental_resistance + 0.5, 1);
+	// Check for Holy/Shadow element Mobs while using a Fire/Water/Wind/Earth magic skill 
+	if ((6 == target_element || 7 == target_element) && n_A_Weapon_zokusei > 0 && n_A_Weapon_zokusei < 5)
+	{
+		// [Wizard Link#445] adds ignore 50% of Holy/Shadow element Fire/Water/Wind/Earth Resistance, limited to 100%.		
+		if (SkillSearch(445))
+			elemental_resistance = Math.min(elemental_resistance + 0.5, 1);
 
-	// Valkyrie gear resist ignore are not effective when the user has Wizard Spirit.
-	else{
-		if ((6 == target_element || 7 == target_element) && n_A_Weapon_zokusei > 0 && n_A_Weapon_zokusei < 5){
+		// Valkyrie gear resist ignore are not effective when the user has Wizard Spirit.
+		else{	
 			// Wearing both [Reginleif's Brand#1888] and [Prima's Vanity#1889] adds ignore 25% of Holy/Shadow element Fire/Water/Wind/Earth Resistance.
-			if (EquipNumSearch(1888) && EquipNumSearch(1889)){
+			if (EquipNumSearch(1888) && EquipNumSearch(1889))
+			{
 				elemental_resistance = Math.min(elemental_resistance + 0.25, 1);
 			}
 			// [Reginleif's Brand#1888] adds ignore 10% of Holy/Shadow element Fire/Water/Wind/Earth Resistance.
-			else if (EquipNumSearch(1888)){
+			else if (EquipNumSearch(1888))
+			{
 				elemental_resistance = Math.min(elemental_resistance + 0.1, 1);
 			}
 			// [Prima's Vanity#1889] adds ignore 20% of Holy/Shadow element Fire/Water/Wind/Earth Resistance.
-			else if (EquipNumSearch(1889)){
+			else if (EquipNumSearch(1889))
+			{
 				elemental_resistance = Math.min(elemental_resistance + 0.2, 1);
 			}
 		}

--- a/js/item.js
+++ b/js/item.js
@@ -1945,7 +1945,7 @@ ItemOBJ = [
 ,[1885,60,0,6,0,1,100,80,"Kara's Blessing","","Ignore 10% of Magical Reflect Damage.<br>10% more physical and magical damage against Valkyrie Kara.<br>10% resistance against Valkyrie Kara.",194,1,7,1,58,5,155,100,0]
 ,[1886,61,1,3,0,1,50,65,"Brynhildr's Stand","",0,19,5,64,20,62,20,66,20,65,20,0]
 ,[1887,62,0,5,0,1,50,1,"Hildr's Veil","","10% more physical and magical damage against Valkyrie Hildr.<br>10% resistance against Valkyrie Hildr.",194,1,7,1,15,4,58,5,0]
-,[1888,62,0,5,0,1,50,1,"Reginleif's Brand","","5% more physical and magical damage against Valkyrie Reginlief and Valkyrie Prima.<br>10% resistance against Valkyrie Reginlief.",194,1,7,1,19,4,58,5,0]
+,[1888,62,0,5,0,1,50,1,"Reginleif's Brand","","Ignore 10% of Holy and Shadow elemental resistance with Fire/Water/Wind/Earth magic.<br>5% more physical and magical damage against Valkyrie Reginlief and Valkyrie Prima.<br>10% resistance against Valkyrie Reginlief.",194,1,7,1,19,4,58,5,0]
 ,[1889,63,0,3,0,1,100,70,"Prima's Vanity","","Fast movement all the time<br>Ignore 20% of Holy and Shadow elemental resistance with Fire/Water/Wind/Earth magic.<br>5% more physical and magical damage against Valkyrie Reginlief and Valkyrie Prima.<br>10% resistance against Valkyrie Prima.",194,1,7,1,58,5,0]
 ,[1890,63,0,3,0,1,100,70,"Sigrun's Journey","","Fast movement all the time<br>Ignore 20% of Magical Reflect Damage.<br>5% more physical and magical damage against Valkyrie Sigrun and Valkyrie Olrun.<br>10% resistance against Valkyrie Sigrun and Valkyrie Olrun.",194,1,7,1,0]
 ,[1891,100,0,0,0,0,0,0,"Herja's Fury and Hildr's Veil and Prima's Vanity","","5% more Physical and Magical damage against All BoTN Valkyries" ,7,1,0]


### PR DESCRIPTION
Add 10% resistance ignore to Reginleif's Brand.
Per blackstar, having both  [Reginleif's Brand#1888] and [Prima's Vanity#1889] caps the resistance ignore to 25%